### PR TITLE
Eliminate instance-dir from parameters

### DIFF
--- a/bin/certhub-certbot-run
+++ b/bin/certhub-certbot-run
@@ -14,16 +14,15 @@ XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
-    ${ECHO} "${0}: /path/to/certhub/instance.example.com /path/to/certbot [certbot certonly args...]"
+    ${ECHO} "${0}: cert-output-file csr-input-file certbot [certbot certonly args...]"
     return 1
 }
 
 certhub_certbot_run() {
     WORKDIR="${1}"
-    INSTANCE_DIR="${2}"
-    CSR_PATH="${INSTANCE_DIR}/${CERTHUB_CSR_NAME:-csr.pem}"
-    FC_PATH="${INSTANCE_DIR}/${CERTHUB_FULLCHAIN_NAME:-fullchain.pem}"
-    shift 2
+    FC_PATH="${2}"
+    CSR_PATH="${3}"
+    shift 3
 
     ${ECHO} certonly \
         --csr "${CSR_PATH}" \
@@ -41,7 +40,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ "${#}" -gt 1 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
+if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
     certhub_certbot_run "${WORKDIR}" "${@}"
 else
     usage

--- a/bin/certhub-dehydrated-run
+++ b/bin/certhub-dehydrated-run
@@ -14,16 +14,15 @@ XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
-    ${ECHO} "${0}: /path/to/certhub/instance.example.com dehydrated [dehydrated args...]"
+    ${ECHO} "${0}: cert-output-file csr-input-file dehydrated [dehydrated args...]"
     return 1
 }
 
 certhub_dehydrated_run() {
     WORKDIR="${1}"
-    INSTANCE_DIR="${2}"
-    CSR_PATH="${INSTANCE_DIR}/${CERTHUB_CSR_NAME:-csr.pem}"
-    FC_PATH="${INSTANCE_DIR}/${CERTHUB_FULLCHAIN_NAME:-fullchain.pem}"
-    shift 2
+    FC_PATH="${2}"
+    CSR_PATH="${3}"
+    shift 3
 
     ${ECHO} --full-chain \
         --signcsr "${CSR_PATH}" | ${XARGS} "${@}" > "${WORKDIR}/fullchain.pem"
@@ -38,7 +37,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ "${#}" -gt 1 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
+if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
     certhub_dehydrated_run "${WORKDIR}" "${@}"
 else
     usage

--- a/bin/certhub-lego-run
+++ b/bin/certhub-lego-run
@@ -15,17 +15,16 @@ BASENAME=/usr/bin/basename
 
 # Print usage message and exit.
 usage() {
-    ${ECHO} "${0}: /path/to/certhub/instance.example.com /path/to/lego/dir /path/to/lego [lego run args...]"
+    ${ECHO} "${0}: cert-output-file csr-input-file lego-dir lego [lego run args...]"
     return 1
 }
 
 certhub_lego_run() {
-    INSTANCE_DIR="${1}"
-    CSR_PATH="${INSTANCE_DIR}/${CERTHUB_CSR_NAME:-csr.pem}"
-    FC_PATH="${INSTANCE_DIR}/${CERTHUB_FULLCHAIN_NAME:-fullchain.pem}"
+    FC_PATH="${1}"
+    CSR_PATH="${2}"
 
     # Setup temp dir inside lego directory for new certificate.
-    LEGO_DIR="${2}"
+    LEGO_DIR="${3}"
     WORKDIR=$(${MKTEMP} -d -p "${LEGO_DIR}/certificates")
     cleanup() {
         ${RM} -rf "${WORKDIR}"
@@ -34,7 +33,7 @@ certhub_lego_run() {
 
     OUTFILEABS="${WORKDIR}/fullchain.crt"
     OUTFILEBASE=$(${BASENAME} "${WORKDIR}")/fullchain
-    shift 2
+    shift 3
 
     ${ECHO} \
         --csr "${CSR_PATH}" \
@@ -45,7 +44,7 @@ certhub_lego_run() {
     ${MV} "${OUTFILEABS}" "${FC_PATH}"
 }
 
-if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
+if [ "${#}" -gt 3 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
     certhub_lego_run "${@}"
 else
     usage

--- a/bin/certhub-message-format
+++ b/bin/certhub-message-format
@@ -55,7 +55,7 @@ certhub_message_format() {
     fi
 }
 
-if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] && ( [ "${2}" = "req" ] || [ "${2}" = "x509" ] ) ; then
+if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] && { [ "${2}" = "req" ] || [ "${2}" = "x509" ] } ; then
     certhub_message_format "${@}"
 else
     usage

--- a/bin/certhub-message-format
+++ b/bin/certhub-message-format
@@ -13,7 +13,7 @@ XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
-    ${ECHO} "${0}: /path/to/certhub/instance.example.com command [args...]"
+    ${ECHO} "${0}: input-pem-file [x509|req] command [args...]"
     return 1
 }
 
@@ -21,39 +21,41 @@ certhub_message_subject() {
     if [ -n "${CERTHUB_MESSAGE_SUBJECT:-}" ]; then
         ${ECHO} "${CERTHUB_MESSAGE_SUBJECT}"
     else
-        INSTANCE_BASE=$(${BASENAME} "${1}")
-        COMMAND_BASE=$(${BASENAME} "${2}")
-
-        ${ECHO} "${CERTHUB_MESSAGE_SUBJECT_PREFIX:-[Certhub]} ${CERTHUB_MESSAGE_ACTION_NAME:-${COMMAND_BASE}} ${CERTHUB_MESSAGE_INSTANCE_NAME:-${INSTANCE_BASE}}"
+        COMMAND_BASE=$(${BASENAME} "${1}")
+        ${ECHO} "${CERTHUB_MESSAGE_SUBJECT_PREFIX:-[Certhub]} ${CERTHUB_MESSAGE_SUBJECT_ACTION:-${COMMAND_BASE}}"
     fi
 }
 
 certhub_message_format() {
-    INSTANCE_DIR="${1}"
-    SUBJECT=$(certhub_message_subject "${1}" "${2}")
-    CERT_LOGOPTS="${CERTHUB_CERT_LOGOPTS:--noout -text -certopt no_pubkey,no_sigdump,no_extensions -sha256 -fingerprint}"
-    FC_PATH="${INSTANCE_DIR}/${CERTHUB_FULLCHAIN_NAME:-fullchain.pem}"
-    REQ_LOGOPTS="${CERTHUB_REQ_LOGOPTS:--noout -text -reqopt no_pubkey,no_sigdump}"
-    REQ_PATH="${INSTANCE_DIR}/${CERTHUB_CSR_NAME:-csr.pem}"
-    shift 1
+    PEM_FILE="${1}"
+    PEM_TYPE="${2}"
+
+    SUBJECT=$(certhub_message_subject "${3}")
+    case "$PEM_TYPE" in
+        x509)
+            TEXTOPTS="${CERTHUB_CERT_TEXTOPTS:--noout -text -certopt no_pubkey,no_sigdump,no_extensions -sha256 -fingerprint}"
+            ;;
+        req)
+            TEXTOPTS="${CERTHUB_CSR_TEXTOPTS:--noout -text -reqopt no_pubkey,no_sigdump}"
+            ;;
+        *)
+            TEXTOPTS=""
+            ;;
+    esac
+    shift 2
 
     ${ECHO} "${SUBJECT}"
     ${ECHO}
 
     "${@}" 2>&1
 
-    if [ -f "${REQ_PATH}" ] && [ -n "${REQ_LOGOPTS}" ]; then
-        ${ECHO} "${REQ_LOGOPTS}" | ${XARGS} ${OPENSSL} req -in "${REQ_PATH}"
-        ${ECHO}
-    fi
-
-    if [ -f "${FC_PATH}" ] && [ -n "${CERT_LOGOPTS}" ]; then
-        ${ECHO} "${CERT_LOGOPTS}" | ${XARGS} ${OPENSSL} x509 -in "${FC_PATH}"
+    if [ -f "${PEM_FILE}" ] && [ -n "${TEXTOPTS}" ]; then
+        ${ECHO} "${TEXTOPTS}" | ${XARGS} ${OPENSSL} "${PEM_TYPE}" -in "${PEM_FILE}"
         ${ECHO}
     fi
 }
 
-if [ "${#}" -gt 1 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ]; then
+if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] && ( [ "${2}" = "req" ] || [ "${2}" = "x509" ] ) ; then
     certhub_message_format "${@}"
 else
     usage

--- a/bin/certhub-message-format
+++ b/bin/certhub-message-format
@@ -55,7 +55,7 @@ certhub_message_format() {
     fi
 }
 
-if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] && { [ "${2}" = "req" ] || [ "${2}" = "x509" ] } ; then
+if [ "${#}" -gt 2 ] && [ "${1:-}" != "-h" ] && [ "${1:-}" != "--help" ] && { [ "${2}" = "req" ] || [ "${2}" = "x509" ]; } ; then
     certhub_message_format "${@}"
 else
     usage

--- a/doc/certhub-certbot-run.1.md
+++ b/doc/certhub-certbot-run.1.md
@@ -23,7 +23,7 @@ certificate is committed to the repository as well.
     git gau-exec /home/certhub/certs.git \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format {}/example.com \
+    certhub-message-format {}/example.com/fullchain.pem x509 \
     certhub-certbot-run {}/example.com/fullchain.pem {}/example.com/csr.pem \
     certbot --config /home/certhub/config/example.com.certbot.ini
 

--- a/doc/certhub-certbot-run.1.md
+++ b/doc/certhub-certbot-run.1.md
@@ -8,12 +8,12 @@ certhub-certbot-run - Runs certbot certonly command once
 
 # SYNOPSIS
 
-certhub-certbot-run instance-directory certbot [certbot-certonly-args...]
+certhub-certbot-run output-cert-file input-csr-file certbot [certbot-certonly-args...]
 
 # DESCRIPTION
 
-Runs the given *certbot* binary with CSR read from instance-directory. Writes
-the resulting certificate to the instance-directory as well.
+Runs the given *certbot* binary with CSR read from input-csr-file. Writes
+the resulting certificate to the output-cert-file as well.
 
 # EXAMPLES
 
@@ -24,20 +24,10 @@ certificate is committed to the repository as well.
     git gau-ac \
     git gau-xargs -I{} \
     certhub-message-format {}/example.com \
-    certhub-certbot-run {}/example.com \
+    certhub-certbot-run {}/example.com/fullchain.pem {}/example.com/csr.pem \
     certbot --config /home/certhub/config/example.com.certbot.ini
-
-# VARIABLES
-
-CERTHUB\_CSR\_NAME
-:   Specify the filename used for the CSR inside the repository. Defaults to
-    *csr.pem*.
-
-CERTHUB\_FULLCHAIN\_NAME
-:   Specify the filename used for the certificate inside the repository.
-    Defaults to *fullchain.pem*.
 
 # SEE ALSO
 
-`dehydrated` (1).
+`certbot` (1).
 `certhub-message-format` (1).

--- a/doc/certhub-dehydrated-run.1.md
+++ b/doc/certhub-dehydrated-run.1.md
@@ -8,12 +8,12 @@ certhub-dehydrated-run - Runs dehydrated --signcsr command once
 
 # SYNOPSIS
 
-certhub-dehydrated-run instance-directory dehydrated [dehydrated-args...]
+certhub-dehydrated-run output-cert-file input-csr-file dehydrated [dehydrated-args...]
 
 # DESCRIPTION
 
-Runs the given *dehydrated* binary with CSR read from instance-directory. Writes
-the resulting certificate to the instance-directory as well.
+Runs the given *dehydrated* binary with CSR read from input-csr-file. Writes
+the resulting certificate to the output-cert-file as well.
 
 # EXAMPLES
 
@@ -24,18 +24,8 @@ certificate is committed to the repository as well.
     git gau-ac \
     git gau-xargs -I{} \
     certhub-message-format {}/example.com \
-    certhub-dehydrated-run {}/example.com \
+    certhub-dehydrated-run {}/example.com/fullchain.pem {}/example.com/csr.pem \
     dehydrated --config /home/certhub/config/example.com.dehydrated
-
-# VARIABLES
-
-CERTHUB\_CSR\_NAME
-:   Specify the filename used for the CSR inside the repository. Defaults to
-    *csr.pem*.
-
-CERTHUB\_FULLCHAIN\_NAME
-:   Specify the filename used for the certificate inside the repository.
-    Defaults to *fullchain.pem*.
 
 # SEE ALSO
 

--- a/doc/certhub-dehydrated-run.1.md
+++ b/doc/certhub-dehydrated-run.1.md
@@ -23,7 +23,7 @@ certificate is committed to the repository as well.
     git gau-exec /home/certhub/certs.git \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format {}/example.com \
+    certhub-message-format {}/example.com/fullchain.pem x509 \
     certhub-dehydrated-run {}/example.com/fullchain.pem {}/example.com/csr.pem \
     dehydrated --config /home/certhub/config/example.com.dehydrated
 

--- a/doc/certhub-lego-run.1.md
+++ b/doc/certhub-lego-run.1.md
@@ -8,12 +8,12 @@ certhub-lego-run - Runs lego run command once
 
 # SYNOPSIS
 
-certhub-lego-run instance-directory lego-directory lego [lego-run-args...]
+certhub-lego-run output-cert-file input-csr-file lego-directory lego [lego-run-args...]
 
 # DESCRIPTION
 
-Runs the given *lego* binary with CSR read from instance-directory. Writes
-the resulting certificate to the instance-directory as well.
+Runs the given *lego* binary with CSR read from input-csr-file. Writes
+the resulting certificate to the output-cert-file as well.
 
 Note, *lego-directory* must point to the directory where lego stores account
 data and certificates (usually $HOME/.lego).
@@ -27,19 +27,9 @@ certificate is committed to the repository as well.
     git gau-ac \
     git gau-xargs -I{} \
     xargs -a /home/certhub/config/example.com.lego.ini
-    certhub-message-format {}/example.com \
+    certhub-message-format {}/example.com/fullchain.pem {}/example.com/csr.pem \
     certhub-lego-run {}/example.com /home/certhub/lego \
     lego
-
-# VARIABLES
-
-CERTHUB\_CSR\_NAME
-:   Specify the filename used for the CSR inside the repository. Defaults to
-    *csr.pem*.
-
-CERTHUB\_FULLCHAIN\_NAME
-:   Specify the filename used for the certificate inside the repository.
-    Defaults to *fullchain.pem*.
 
 # SEE ALSO
 

--- a/doc/certhub-lego-run.1.md
+++ b/doc/certhub-lego-run.1.md
@@ -27,8 +27,8 @@ certificate is committed to the repository as well.
     git gau-ac \
     git gau-xargs -I{} \
     xargs -a /home/certhub/config/example.com.lego.ini
-    certhub-message-format {}/example.com/fullchain.pem {}/example.com/csr.pem \
-    certhub-lego-run {}/example.com /home/certhub/lego \
+    certhub-message-format {}/example.com/fullchain.pem x509 \
+    certhub-lego-run {}/example.com/fullchain.pem {}/example.com/csr.pem /home/certhub/lego \
     lego
 
 # SEE ALSO

--- a/doc/certhub-message-format.1.md
+++ b/doc/certhub-message-format.1.md
@@ -8,18 +8,16 @@ certhub-message-format - Run a command and format its output.
 
 # SYNOPSIS
 
-certhub-message-format instance-directory command [args...]
+certhub-message-format input-pem-file [x509|req] command [args...]
 
 # DESCRIPTION
 
 Rens the specified command and capture its standard output and standard error.
-Formats the output in a way which suites *git-commit*. Also attaches CSR and
-certificate details if such files are found in the specified instance
-directory.
+Formats the output in a way which suites *git-commit*. Also attaches CSR or
+certificate details if the specified input-pem-file exists.
 
-Use this command in combination with *certhub-csr-import* or
-*certhub-certbot-run* and *git-gau-exec* / *git-gau-ac* when adding / renewing
-certificates in an automated way.
+Use this command in combination with *certhub-certbot-run* and *git-gau-exec* /
+*git-gau-ac* when adding / renewing certificates in an automated way.
 
 
 # VARIABLES
@@ -31,27 +29,15 @@ CERTHUB\_MESSAGE\_SUBJECT\_PREFIX
 :   Message prefix when automated subject generation is enabled. Defaults to
     [Certhub].
 
-CERTHUB\_MESSAGE\_ACTION\_NAME
+CERTHUB\_MESSAGE\_SUBJECT\_ACTION
 :   Message action name when automated subject generation is enabled. Defaults
     to basename of executed command.
 
-CERTHUB\_MESSAGE\_INSTANCE\_NAME
-:   Instance name when automated subject generation is enabled. Defaults
-    to basename of given instance directory.
-
-CERTHUB\_CSR\_NAME
-:   Specify the filename used for the CSR inside the repository. Defaults to
-    *csr.pem*.
-
-CERTHUB\_FULLCHAIN\_NAME
-:   Specify the filename used for the certificate inside the repository.
-    Defaults to *fullchain.pem*.
-
-CERTHUB\_REQ\_LOGOPTS
+CERTHUB\_REQ\_TEXTOPTS
 :   Output options as understood by *openssl req*. Defaults to: --noout -text
     -reqopt no\_pubkey,no\_sigdump
 
-CERTHUB\_CERT\_LOGOPTS
+CERTHUB\_CERT\_TEXTOPTS
 :   Output options as understood by *openssl x509*. Defaults to: --noout -text
     -certopt no\_pubkey,no\_sigdump,no\_extensions -sha256 -fingerprint
 

--- a/integration-test/test/test-certbot.sh
+++ b/integration-test/test/test-certbot.sh
@@ -12,7 +12,7 @@ cat <<EOF | /bin/su -s /bin/sh - certhub
     git gau-exec /home/certhub/certs.git \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format {} \
+    certhub-message-format "{}/certbot-test/csr.pem" req \
     rsync -av "/home/certhub/setup/certbot-test" {}
 EOF
 

--- a/integration-test/test/test-dehydrated.sh
+++ b/integration-test/test/test-dehydrated.sh
@@ -12,7 +12,7 @@ cat <<EOF | /bin/su -s /bin/sh - certhub
     git gau-exec /home/certhub/certs.git \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format {} \
+    certhub-message-format "{}/dehydrated-test/csr.pem" req \
     rsync -av "/home/certhub/setup/dehydrated-test" {}
 EOF
 

--- a/integration-test/test/test-lego.sh
+++ b/integration-test/test/test-lego.sh
@@ -12,7 +12,7 @@ cat <<EOF | /bin/su -s /bin/sh - certhub
     git gau-exec /home/certhub/certs.git \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format {} \
+    certhub-message-format "{}/lego-test/csr.pem" req \
     rsync -av "/home/certhub/setup/lego-test" {}
 EOF
 

--- a/lib/systemd/certhub-certbot-run@.service
+++ b/lib/systemd/certhub-certbot-run@.service
@@ -13,6 +13,8 @@ Group=certhub
 Environment=CERTHUB_REPO=/home/certhub/certs.git
 
 Environment="CERTHUB_MESSAGE_SUBJECT=[Certhub] Certbot renew %i"
+Environment=CERTHUB_CERT_NAME=fullchain.pem
+Environment=CERTHUB_CSR_NAME=csr.pem
 
 # Additional git environment variables.
 Environment=GIT_AUTHOR_EMAIL=certhub@%H
@@ -33,7 +35,7 @@ ExecStart=/usr/bin/env \
     git gau-ac \
     git gau-xargs -I{} \
     certhub-message-format "{}/%i" \
-    certhub-certbot-run "{}/%i" \
+    certhub-certbot-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} \
     certbot $CERTBOT_ARGS --config $CERTBOT_CONFIG
 
 SyslogIdentifier=certhub-certbot-run

--- a/lib/systemd/certhub-certbot-run@.service
+++ b/lib/systemd/certhub-certbot-run@.service
@@ -34,8 +34,8 @@ ExecStart=/usr/bin/env \
     git gau-exec $CERTHUB_REPO \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format "{}/%i" \
-    certhub-certbot-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} \
+    certhub-message-format "{}/%i/${CERTHUB_CERT_NAME}" x509 \
+    certhub-certbot-run "{}/%i/${CERTHUB_CERT_NAME}" "{}/%i/${CERTHUB_CSR_NAME}" \
     certbot $CERTBOT_ARGS --config $CERTBOT_CONFIG
 
 SyslogIdentifier=certhub-certbot-run

--- a/lib/systemd/certhub-dehydrated-run@.service
+++ b/lib/systemd/certhub-dehydrated-run@.service
@@ -34,8 +34,8 @@ ExecStart=/usr/bin/env \
     git gau-exec $CERTHUB_REPO \
     git gau-ac \
     git gau-xargs -I{} \
-    certhub-message-format "{}/%i" \
-    certhub-dehydrated-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} \
+    certhub-message-format "{}/%i/${CERTHUB_CERT_NAME}" x509 \
+    certhub-dehydrated-run "{}/%i/${CERTHUB_CERT_NAME}" "{}/%i/${CERTHUB_CSR_NAME}" \
     dehydrated $DEHYDRATED_ARGS --config $DEHYDRATED_CONFIG
 
 SyslogIdentifier=certhub-dehydrated-run

--- a/lib/systemd/certhub-dehydrated-run@.service
+++ b/lib/systemd/certhub-dehydrated-run@.service
@@ -13,6 +13,8 @@ Group=certhub
 Environment=CERTHUB_REPO=/home/certhub/certs.git
 
 Environment="CERTHUB_MESSAGE_SUBJECT=[Certhub] Dehydrated renew %i"
+Environment=CERTHUB_CERT_NAME=fullchain.pem
+Environment=CERTHUB_CSR_NAME=csr.pem
 
 # Additional git environment variables.
 Environment=GIT_AUTHOR_EMAIL=certhub@%H
@@ -33,7 +35,7 @@ ExecStart=/usr/bin/env \
     git gau-ac \
     git gau-xargs -I{} \
     certhub-message-format "{}/%i" \
-    certhub-dehydrated-run "{}/%i" \
+    certhub-dehydrated-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} \
     dehydrated $DEHYDRATED_ARGS --config $DEHYDRATED_CONFIG
 
 SyslogIdentifier=certhub-dehydrated-run

--- a/lib/systemd/certhub-lego-run@.service
+++ b/lib/systemd/certhub-lego-run@.service
@@ -12,6 +12,8 @@ Group=certhub
 Environment=CERTHUB_REPO=/home/certhub/certs.git
 
 Environment="CERTHUB_MESSAGE_SUBJECT=[Certhub] lego renew %i"
+Environment=CERTHUB_CERT_NAME=fullchain.pem
+Environment=CERTHUB_CSR_NAME=csr.pem
 
 # Additional git environment variables.
 Environment=GIT_AUTHOR_EMAIL=certhub@%H
@@ -30,7 +32,7 @@ ExecStart=/usr/bin/env \
     git gau-xargs -I{} \
     xargs -a ${LEGO_CONFIG} \
     certhub-message-format "{}/%i" \
-    certhub-lego-run "{}/%i" ${LEGO_DIR} \
+    certhub-lego-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} ${LEGO_DIR} \
     lego $LEGO_ARGS
 
 SyslogIdentifier=certhub-lego-run

--- a/lib/systemd/certhub-lego-run@.service
+++ b/lib/systemd/certhub-lego-run@.service
@@ -31,8 +31,8 @@ ExecStart=/usr/bin/env \
     git gau-ac \
     git gau-xargs -I{} \
     xargs -a ${LEGO_CONFIG} \
-    certhub-message-format "{}/%i" \
-    certhub-lego-run "{}/%i"/${CERTHUB_CERT_NAME} "{}/%i"/${CERTHUB_CSR_NAME} ${LEGO_DIR} \
+    certhub-message-format "{}/%i/${CERTHUB_CERT_NAME}" x509 \
+    certhub-lego-run "{}/%i/${CERTHUB_CERT_NAME}" "{}/%i/${CERTHUB_CSR_NAME}" ${LEGO_DIR} \
     lego $LEGO_ARGS
 
 SyslogIdentifier=certhub-lego-run


### PR DESCRIPTION
Most of the executables take an `instance-dir` parameter and then use environment variables to figure out on which files to operate (mostly `csr.pem` and `fullchain.pem`). This is too messy and hard to understand. Let's just specify the required paths on the command line explicitly.