### PR TITLE
Add optional environment files

### DIFF
--- a/doc/certhub-cert-expiry@.service.8.rst
+++ b/doc/certhub-cert-expiry@.service.8.rst
@@ -55,6 +55,27 @@ Environment
    ``/var/lib/certhub/status/%i.expiry.status``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-cert-expiry.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-cert-expiry.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-cert-export@.service.8.rst
+++ b/doc/certhub-cert-export@.service.8.rst
@@ -46,6 +46,27 @@ Environment
    ``--checksum --delete --devices --links --perms --recursive --specials --verbose``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-cert-export.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-cert-export.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-cert-reload@.service.8.rst
+++ b/doc/certhub-cert-reload@.service.8.rst
@@ -30,6 +30,27 @@ Environment
    ``/etc/certhub/%i.services-reload.txt``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-cert-reload.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-cert-reload.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-certbot-run@.service.8.rst
+++ b/doc/certhub-certbot-run@.service.8.rst
@@ -52,6 +52,27 @@ Environment
    ``/etc/certhub/%i.certbot.ini``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-certbot-run.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-certbot-run.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-dehydrated-run@.service.8.rst
+++ b/doc/certhub-dehydrated-run@.service.8.rst
@@ -52,6 +52,27 @@ Environment
    ``/etc/certhub/%i.dehydrated.conf``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-dehydrated-run.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-dehydrated-run.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-lego-run@.service.8.rst
+++ b/doc/certhub-lego-run@.service.8.rst
@@ -62,6 +62,27 @@ Environment
    certificates. Defaults to: ``var/lib/certhub/private/lego``
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-lego-run.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-lego-run.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/certhub-repo-push@.service.8.rst
+++ b/doc/certhub-repo-push@.service.8.rst
@@ -45,6 +45,27 @@ Environment
    Refspec for the git push command. Empty by default.
 
 
+Files
+-----
+
+.. envfile:: /etc/certhub/env
+
+   Optional environment file shared by all instances and certhub services.
+
+.. envfile:: /etc/certhub/%i.env
+
+   Optional per-instance environment file shared by all certhub services.
+
+.. envfile:: /etc/certhub/certhub-repo-push.env
+
+   Optional per-service environment file shared by all certhub service
+   instances.
+
+.. envfile:: /etc/certhub/%i.certhub-repo-push.env
+
+   Optional per-instance and per-service environment file.
+
+
 See Also
 --------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -190,3 +190,9 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+
+# -- Ad-hoc extensions -------------------------------------------------------
+
+def setup(app):
+    app.add_object_type('envfile', 'envfile', indextemplate='environment file; %s')

--- a/lib/systemd/dropins/certhub-paths.conf
+++ b/lib/systemd/dropins/certhub-paths.conf
@@ -9,6 +9,22 @@
 # - certhub-lego-run@.service
 # - certhub-repo-push@.service
 
+# Optional environment file shared by all instances and certhub services.
+#
+EnvironmentFile=-/etc/certhub/env
+
+# Optional per-instance environment file shared by all certhub services.
+#
+EnvironmentFile=-/etc/certhub/%i.env
+
+# Optional per-service environment file shared by all certhub service instances.
+#
+EnvironmentFile=-/etc/certhub/%p.env
+
+# Optional per-instance and per-service environment file.
+#
+EnvironmentFile=-/etc/certhub/%i.%p.env
+
 # CERTHUB_REPO:
 # URL of the repository where certificates are stored.
 #


### PR DESCRIPTION
Add the option to configure services on a per-instance and/or per-service base using environment files inside /etc/certhub. Environment files do have a slightly simpler syntax in compared to services drop-ins. Also changes in environment files do not require a systemd daemon reload.